### PR TITLE
chore: Bump govy version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/OpenSLO/go-sdk
 go 1.23
 
 require (
-	github.com/nobl9/govy v0.12.1
+	github.com/nobl9/govy v0.14.0
 	sigs.k8s.io/yaml v1.4.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -1,8 +1,8 @@
 github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
-github.com/nobl9/govy v0.12.1 h1:xMPPPyOFExaHYN75aEsiEuOXC2z8i44MLTqccjiEkAg=
-github.com/nobl9/govy v0.12.1/go.mod h1:O+xSiKwZ6gs/orRvH5qLkfkgyT7CkuXprRIq3C5uNXQ=
+github.com/nobl9/govy v0.14.0 h1:OvfXTL0Li7ZPuPsfye3EDD/p/umLSru2hit5/Xa9PCQ=
+github.com/nobl9/govy v0.14.0/go.mod h1:O+xSiKwZ6gs/orRvH5qLkfkgyT7CkuXprRIq3C5uNXQ=
 golang.org/x/exp v0.0.0-20240808152545-0cdaa3abc0fa h1:ELnwvuAXPNtPk1TJRuGkI9fDTwym6AYBu0qzT8AcHdI=
 golang.org/x/exp v0.0.0-20240808152545-0cdaa3abc0fa/go.mod h1:akd2r19cwCdwSwWeIdzYQGa/EZZyqcOdwWiwj5L5eKQ=
 golang.org/x/mod v0.20.0 h1:utOm6MM3R3dnawAiJgn0y+xvuYRsm1RKM/4giyfDgV0=

--- a/pkg/openslo/v2alpha/objects.go
+++ b/pkg/openslo/v2alpha/objects.go
@@ -99,14 +99,7 @@ func validationRulesMetadata[T any](getter func(T) Metadata) govy.PropertyRules[
 		)
 }
 
-var (
-	// nolint: lll
-	labelKeyRegexp = regexp.MustCompile(
-		`^([a-z0-9]([-a-z0-9]{0,61}[a-z0-9])?(\.[a-z0-9]([-a-z0-9]{0,61}[a-z0-9])?)*/)?[a-z0-9]([-._a-z0-9]{0,61}[a-z0-9])?$`,
-	)
-	labelKeyLengthRegexp = regexp.MustCompile(`^(.{0,253}/)?.{0,63}$`)
-	labelValueRegexp     = regexp.MustCompile(`^([a-z0-9]([-._a-z0-9]{0,61}[a-z0-9])?)?$`)
-)
+var labelValueRegexp = regexp.MustCompile(`^([a-z0-9]([-._a-z0-9]{0,61}[a-z0-9])?)?$`)
 
 func labelsValidator() govy.Validator[Labels] {
 	return govy.New(

--- a/pkg/openslo/v2alpha/objects.go
+++ b/pkg/openslo/v2alpha/objects.go
@@ -112,10 +112,7 @@ func labelsValidator() govy.Validator[Labels] {
 	return govy.New(
 		govy.ForMap(govy.GetSelf[Labels]()).
 			Cascade(govy.CascadeModeStop).
-			RulesForKeys(
-				rules.StringMatchRegexp(labelKeyLengthRegexp),
-				rules.StringMatchRegexp(labelKeyRegexp).WithExamples("my-domain.org/my-key", "openslo.com/annotation"),
-			).
+			RulesForKeys(rules.StringKubernetesQualifiedName()).
 			RulesForValues(rules.StringMatchRegexp(labelValueRegexp).WithExamples("my-label", "my.domain_123-label")),
 	)
 }
@@ -124,9 +121,6 @@ func annotationsValidator() govy.Validator[Annotations] {
 	return govy.New(
 		govy.ForMap(govy.GetSelf[Annotations]()).
 			Cascade(govy.CascadeModeStop).
-			RulesForKeys(
-				rules.StringMatchRegexp(labelKeyLengthRegexp),
-				rules.StringMatchRegexp(labelKeyRegexp).WithExamples("my-domain.org/my-key", "openslo.com/annotation"),
-			),
+			RulesForKeys(rules.StringKubernetesQualifiedName()),
 	)
 }

--- a/pkg/openslo/v2alpha/objects_test.go
+++ b/pkg/openslo/v2alpha/objects_test.go
@@ -63,7 +63,9 @@ var labelKeyTestCases = []struct {
 	{"net", false},
 	{"9net", false},
 	{"net9", false},
+	{"nEt", false},
 	{"openslo.com/service", false},
+	{"openslo.com/Service", false},
 	{"domain/service", false},
 	{"domain.org/service", false},
 	{"domain.this.org/service", false},
@@ -77,7 +79,6 @@ var labelKeyTestCases = []struct {
 	{"_net", true},
 	{"-net", true},
 	{".net", true},
-	{"nEt", true},
 	{"openslo.com/", true},
 	{"openslo.com!/service", true},
 	{"-openslo.com/service", true},
@@ -158,7 +159,7 @@ func getLabelsTestCases(t *testing.T, propertyPath string) map[string]labelsTest
 				error: govytest.ExpectedRuleError{
 					PropertyName: propertyPath + "." + tc.in,
 					IsKeyError:   true,
-					Code:         rules.ErrorCodeStringMatchRegexp,
+					Code:         rules.ErrorCodeStringKubernetesQualifiedName,
 				},
 			}
 		} else {
@@ -197,7 +198,7 @@ func getAnnotationsTestCases(t *testing.T, propertyPath string) map[string]annot
 				error: govytest.ExpectedRuleError{
 					PropertyName: propertyPath + "." + tc.in,
 					IsKeyError:   true,
-					Code:         rules.ErrorCodeStringMatchRegexp,
+					Code:         rules.ErrorCodeStringKubernetesQualifiedName,
 				},
 			}
 		} else {

--- a/pkg/openslosdk/validation_test.go
+++ b/pkg/openslosdk/validation_test.go
@@ -43,9 +43,9 @@ func TestValidate(t *testing.T) {
     - property is required but was empty
 Validation for openslo/v1 Service at index 1 has failed for the following properties:
   - 'metadata.name' with value 'service 1':
-    - string must match regular expression: '^[a-z0-9]([-a-z0-9]{0,61}[a-z0-9])?$' (e.g. 'my-name', '123-abc'); an RFC-1123 compliant label name must consist of lower case alphanumeric characters or '-', and must start and end with an alphanumeric character
+    - string must match regular expression: '^[a-z0-9]([-a-z0-9]*[a-z0-9])?$' (e.g. 'my-name', '123-abc'); an RFC-1123 compliant label name must consist of lower case alphanumeric characters or '-', and must start and end with an alphanumeric character
 Validation for openslo.com/v2alpha Service at index 2 has failed for the following properties:
   - 'metadata.labels.invalid key' with key 'invalid key':
-    - string must match regular expression: '^([a-z0-9]([-a-z0-9]{0,61}[a-z0-9])?(\.[a-z0-9]([-a-z0-9]{0,61}[a-z0-9])?)*/)?[a-z0-9]([-._a-z0-9]{0,61}[a-z0-9])?$' (e.g. 'my-domain.org/my-key', 'openslo.com/annotation')`
+    - name part string must match regular expression: '^([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$' (e.g. 'my.domain/MyName', 'MyName', 'my.name', '123-abc'); Kubernetes Qualified Name must consist of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character with an optional DNS subdomain prefix and '/'`
 	assert.Equal(t, expectedError, err.Error())
 }


### PR DESCRIPTION
Switched `v2alpha.Labels` and `v2alpha.Annotations` keys validation to govy `rules.KubernetesQualifiedName` rule.