### PR TITLE
fix: Correct validation rules for v1 labels and annotations

### DIFF
--- a/pkg/openslo/v1/objects.go
+++ b/pkg/openslo/v1/objects.go
@@ -122,11 +122,11 @@ func validationRulesMetadata[T any](getter func(T) Metadata) govy.PropertyRules[
 }
 
 var (
-	labelKeyRegexp            = regexp.MustCompile(`^[a-z0-9]([-._a-z0-9]{0,61}[a-z0-9])?$`)
+	labelKeyRegexp            = regexp.MustCompile(`^[a-zA-Z0-9]([-._a-zA-Z0-9]{0,61}[a-zA-Z0-9])?$`)
 	annotationKeyLengthRegexp = regexp.MustCompile(`^(.{0,253}/)?.{0,63}$`)
 	// nolint: lll
 	annotationKeyRegexp = regexp.MustCompile(
-		`^([a-z0-9]([-a-z0-9]{0,61}[a-z0-9])?(\.[a-z0-9]([-a-z0-9]{0,61}[a-z0-9])?)*/)?[a-z0-9]([-._a-z0-9]{0,61}[a-z0-9])?$`,
+		`^([a-z0-9]([-a-z0-9]{0,61}[a-z0-9])?(\.[a-z0-9]([-a-z0-9]{0,61}[a-z0-9])?)*/)?[a-zA-Z0-9]([-._a-zA-Z0-9]{0,61}[a-zA-Z0-9])?$`,
 	)
 )
 

--- a/pkg/openslo/v1/objects_test.go
+++ b/pkg/openslo/v1/objects_test.go
@@ -87,6 +87,7 @@ func getLabelsTestCases(t *testing.T, propertyPath string) map[string]labelsTest
 		{"net_.-this": {}},
 		{"9net": {}},
 		{"net9": {}},
+		{"nEt": {}},
 	}
 	invalidLabels := []Labels{
 		{strings.Repeat("l", 64): {}},
@@ -96,7 +97,6 @@ func getLabelsTestCases(t *testing.T, propertyPath string) map[string]labelsTest
 		{"_net": {}},
 		{"-net": {}},
 		{".net": {}},
-		{"nEt": {}},
 	}
 	testCases := make(map[string]labelsTestCase, len(validLabels)+len(invalidLabels))
 	for _, labels := range validLabels {
@@ -144,10 +144,13 @@ func getAnnotationsTestCases(t *testing.T, propertyPath string) map[string]annot
 		{"net": ""},
 		{"9net": ""},
 		{"net9": ""},
+		{"nEt": ""},
 		{"openslo.com/service": ""},
 		{"domain/service": ""},
 		{"domain.org/service": ""},
 		{"domain.this.org/service": ""},
+		{"domain.this.org/service.foo": ""},
+		{"nobl9.com/spec.indicator.metricSource": ""},
 	}
 	invalidAnnotations := []Annotations{
 		{strings.Repeat("l", 64): ""},
@@ -160,7 +163,6 @@ func getAnnotationsTestCases(t *testing.T, propertyPath string) map[string]annot
 		{"_net": ""},
 		{"-net": ""},
 		{".net": ""},
-		{"nEt": ""},
 		{"openslo.com/": ""},
 		{"openslo.com!/service": ""},
 		{"-openslo.com/service": ""},

--- a/pkg/openslo/v1/objects_test.go
+++ b/pkg/openslo/v1/objects_test.go
@@ -150,7 +150,7 @@ func getAnnotationsTestCases(t *testing.T, propertyPath string) map[string]annot
 		{"domain.org/service": ""},
 		{"domain.this.org/service": ""},
 		{"domain.this.org/service.foo": ""},
-		{"nobl9.com/spec.indicator.metricSource": ""},
+		{"my-org.com/spec.indicator.metricSource": ""},
 	}
 	invalidAnnotations := []Annotations{
 		{strings.Repeat("l", 64): ""},


### PR DESCRIPTION
Our README.md states that:
![image](https://github.com/user-attachments/assets/66efc286-7837-4ff3-8c86-770a017869a1)

while our current rules do not allow uppercase letters.