### PR TITLE
feat: Add fine grained control over reference resolution

### DIFF
--- a/pkg/openslosdk/reference_config.go
+++ b/pkg/openslosdk/reference_config.go
@@ -1,0 +1,45 @@
+package openslosdk
+
+// ReferenceConfig configures [openslo.Object] references resolution.
+// It is used both by [ReferenceInliner] and [ReferenceExporter].
+// By default, all references are resolved.
+type ReferenceConfig struct {
+	V1 ReferenceConfigV1
+}
+
+// ReferenceConfigV1 configures [openslo.VersionV1] references resolution.
+type ReferenceConfigV1 struct {
+	SLO         ReferenceConfigV1SLO
+	AlertPolicy ReferenceConfigV1AlertPolicy
+}
+
+// ReferenceConfigV1SLO configures [v1.SLO] references resolution.
+type ReferenceConfigV1SLO struct {
+	// AlertPolicy controls whether [openslo.KindAlertPolicy] references should be resolved.
+	AlertPolicy bool
+	// SLI controls whether [openslo.KindSLI] references should be resolved.
+	SLI bool
+}
+
+// ReferenceConfigV1AlertPolicy configures [v1.AlertPolicy] references resolution.
+type ReferenceConfigV1AlertPolicy struct {
+	// AlertPolicy controls whether [openslo.KindAlertCondition] references should be resolved.
+	AlertCondition bool
+	// AlertPolicy controls whether [openslo.KindAlertNotificationTarget] references should be resolved.
+	AlertNotificationTarget bool
+}
+
+func defaultReferenceConfig() ReferenceConfig {
+	return ReferenceConfig{
+		V1: ReferenceConfigV1{
+			SLO: ReferenceConfigV1SLO{
+				AlertPolicy: true,
+				SLI:         true,
+			},
+			AlertPolicy: ReferenceConfigV1AlertPolicy{
+				AlertCondition:          true,
+				AlertNotificationTarget: true,
+			},
+		},
+	}
+}

--- a/pkg/openslosdk/reference_exporter_test.go
+++ b/pkg/openslosdk/reference_exporter_test.go
@@ -15,13 +15,20 @@ func TestReferenceExporter_Export(t *testing.T) {
 	testDataPath := filepath.Join(root, "pkg", "openslosdk", "test_data", "export")
 
 	tests := map[string]struct {
-		filename string
+		filename    string
+		exporterMod func(*ReferenceExporter) *ReferenceExporter
 	}{
 		"v1: Alert Policies": {
 			filename: "v1_alert_policies.yaml",
 		},
 		"v1: SLO": {
 			filename: "v1_slo.yaml",
+		},
+		"custom config, do not resolve anything": {
+			filename: "custom_config.yaml",
+			exporterMod: func(r *ReferenceExporter) *ReferenceExporter {
+				return r.WithConfig(ReferenceConfig{})
+			},
 		},
 	}
 
@@ -38,6 +45,9 @@ func TestReferenceExporter_Export(t *testing.T) {
 
 			// Inline objects.
 			exporter := NewReferenceExporter(inputObjects...)
+			if test.exporterMod != nil {
+				exporter = test.exporterMod(exporter)
+			}
 			inlinedObjects := exporter.Export()
 			assert.Require(t, assert.NotEmpty(t, inlinedObjects))
 

--- a/pkg/openslosdk/reference_inliner.go
+++ b/pkg/openslosdk/reference_inliner.go
@@ -246,7 +246,7 @@ func (r *ReferenceInliner) inlineV1SLOAlertPolicies(slo v1.SLO) (v1.SLO, error) 
 
 func (r *ReferenceInliner) inlineV1SLOSLI(slo v1.SLO) (v1.SLO, error) {
 	if slo.Spec.IndicatorRef == nil {
-		return v1.SLO{}, nil
+		return slo, nil
 	}
 	sli, idx := findObject[v1.SLI](r.references, *slo.Spec.IndicatorRef)
 	if idx == -1 {

--- a/pkg/openslosdk/reference_inliner.go
+++ b/pkg/openslosdk/reference_inliner.go
@@ -11,6 +11,7 @@ import (
 
 func NewReferenceInliner(objects ...openslo.Object) *ReferenceInliner {
 	return &ReferenceInliner{
+		config:                  defaultReferenceConfig(),
 		objects:                 objects,
 		inlined:                 make([]openslo.Object, 0, len(objects)),
 		referencedObjectIndexes: make(map[int]bool),
@@ -19,6 +20,7 @@ func NewReferenceInliner(objects ...openslo.Object) *ReferenceInliner {
 
 // ReferenceInliner is a utility to inline referenced [openslo.Object] in referencing object(s).
 type ReferenceInliner struct {
+	config                  ReferenceConfig
 	objects                 []openslo.Object
 	references              []openslo.Object
 	inlined                 []openslo.Object
@@ -26,13 +28,6 @@ type ReferenceInliner struct {
 	removeRefs              bool
 	err                     error
 	once                    sync.Once
-}
-
-// RemoveReferencedObjects instructs [ReferenceInliner] to remove referenced objects
-// from the result of [ReferenceInliner.Inline].
-func (r *ReferenceInliner) RemoveReferencedObjects() *ReferenceInliner {
-	r.removeRefs = true
-	return r
 }
 
 // Inline finds all referenced objects in the provided slice of [openslo.Object]
@@ -46,6 +41,30 @@ func (r *ReferenceInliner) Inline() ([]openslo.Object, error) {
 		r.inlined, r.err = r.inlineObjects()
 	})
 	return r.inlined, r.err
+}
+
+// RemoveReferencedObjects instructs [ReferenceInliner] to remove referenced objects
+// from the result of [ReferenceInliner.Inline].
+func (r *ReferenceInliner) RemoveReferencedObjects() *ReferenceInliner {
+	r.removeRefs = true
+	return r
+}
+
+// WithConfig allows providing a custom [ReferenceConfig] which can help limit
+// the inlined references to a desired subset.
+// Example:
+//
+//	 // only inline [v1.SLI] reference for [v1.SLO]
+//	 ReferenceConfig{
+//			V1: ReferenceConfigV1{
+//				SLO: &ReferenceConfigV1SLO{
+//					SLI:         true,
+//				},
+//			},
+//		}
+func (r *ReferenceInliner) WithConfig(config ReferenceConfig) *ReferenceInliner {
+	r.config = config
+	return r
 }
 
 func (r *ReferenceInliner) inlineObjects() ([]openslo.Object, error) {
@@ -101,6 +120,23 @@ func (r *ReferenceInliner) inlineV1Object(object openslo.Object) (openslo.Object
 }
 
 func (r *ReferenceInliner) inlineV1AlertPolicy(alertPolicy v1.AlertPolicy) (v1.AlertPolicy, error) {
+	var err error
+	if r.config.V1.AlertPolicy.AlertNotificationTarget {
+		alertPolicy, err = r.inlineV1AlertPolicyTargets(alertPolicy)
+		if err != nil {
+			return v1.AlertPolicy{}, err
+		}
+	}
+	if r.config.V1.AlertPolicy.AlertCondition {
+		alertPolicy, err = r.inlineV1AlertPolicyConditions(alertPolicy)
+		if err != nil {
+			return v1.AlertPolicy{}, err
+		}
+	}
+	return alertPolicy, nil
+}
+
+func (r *ReferenceInliner) inlineV1AlertPolicyTargets(alertPolicy v1.AlertPolicy) (v1.AlertPolicy, error) {
 	for i, target := range alertPolicy.Spec.NotificationTargets {
 		if target.AlertPolicyNotificationTargetRef == nil {
 			continue
@@ -122,6 +158,10 @@ func (r *ReferenceInliner) inlineV1AlertPolicy(alertPolicy v1.AlertPolicy) (v1.A
 		r.referencedObjectIndexes[idx] = true
 		alertPolicy.Spec.NotificationTargets[i] = target
 	}
+	return alertPolicy, nil
+}
+
+func (r *ReferenceInliner) inlineV1AlertPolicyConditions(alertPolicy v1.AlertPolicy) (v1.AlertPolicy, error) {
 	for i, condition := range alertPolicy.Spec.Conditions {
 		if condition.AlertPolicyConditionRef == nil {
 			continue
@@ -147,6 +187,23 @@ func (r *ReferenceInliner) inlineV1AlertPolicy(alertPolicy v1.AlertPolicy) (v1.A
 }
 
 func (r *ReferenceInliner) inlineV1SLO(slo v1.SLO) (v1.SLO, error) {
+	var err error
+	if r.config.V1.SLO.AlertPolicy {
+		slo, err = r.inlineV1SLOAlertPolicies(slo)
+		if err != nil {
+			return v1.SLO{}, err
+		}
+	}
+	if r.config.V1.SLO.SLI {
+		slo, err = r.inlineV1SLOSLI(slo)
+		if err != nil {
+			return v1.SLO{}, err
+		}
+	}
+	return slo, nil
+}
+
+func (r *ReferenceInliner) inlineV1SLOAlertPolicies(slo v1.SLO) (v1.SLO, error) {
 	for i, ap := range slo.Spec.AlertPolicies {
 		var alertPolicy v1.AlertPolicy
 		switch {
@@ -184,22 +241,27 @@ func (r *ReferenceInliner) inlineV1SLO(slo v1.SLO) (v1.SLO, error) {
 		}
 		slo.Spec.AlertPolicies[i] = ap
 	}
-	if slo.Spec.IndicatorRef != nil {
-		sli, idx := findObject[v1.SLI](r.references, *slo.Spec.IndicatorRef)
-		if idx == -1 {
-			return v1.SLO{}, newReferenceNotFoundErr(
-				sli,
-				"spec.indicatorRef",
-				*slo.Spec.IndicatorRef,
-			)
-		}
-		slo.Spec.IndicatorRef = nil
-		slo.Spec.Indicator = &v1.SLOIndicatorInline{
-			Metadata: sli.Metadata,
-			Spec:     sli.Spec,
-		}
-		r.referencedObjectIndexes[idx] = true
+	return slo, nil
+}
+
+func (r *ReferenceInliner) inlineV1SLOSLI(slo v1.SLO) (v1.SLO, error) {
+	if slo.Spec.IndicatorRef == nil {
+		return v1.SLO{}, nil
 	}
+	sli, idx := findObject[v1.SLI](r.references, *slo.Spec.IndicatorRef)
+	if idx == -1 {
+		return v1.SLO{}, newReferenceNotFoundErr(
+			sli,
+			"spec.indicatorRef",
+			*slo.Spec.IndicatorRef,
+		)
+	}
+	slo.Spec.IndicatorRef = nil
+	slo.Spec.Indicator = &v1.SLOIndicatorInline{
+		Metadata: sli.Metadata,
+		Spec:     sli.Spec,
+	}
+	r.referencedObjectIndexes[idx] = true
 	return slo, nil
 }
 

--- a/pkg/openslosdk/reference_inliner_test.go
+++ b/pkg/openslosdk/reference_inliner_test.go
@@ -56,6 +56,12 @@ func TestReferenceInliner_Inline(t *testing.T) {
 			err: errors.New("failed to inline v1.SLO 'my-slo': v1.AlertNotificationTarget 'devs-email-notification'" +
 				" referenced at 'spec.alertPolicies[0].spec.notificationTargets[1].targetRef' does not exist"),
 		},
+		"custom config, do not resolve anything": {
+			filename: "custom_config.yaml",
+			inlinerMod: func(r *ReferenceInliner) *ReferenceInliner {
+				return r.WithConfig(ReferenceConfig{})
+			},
+		},
 	}
 
 	for name, test := range tests {
@@ -75,8 +81,8 @@ func TestReferenceInliner_Inline(t *testing.T) {
 				inliner = test.inlinerMod(inliner)
 			}
 			inlinedObjects, err := inliner.Inline()
-			switch {
-			case test.err == nil:
+			switch test.err {
+			case nil:
 				assert.Require(t, assert.NoError(t, err))
 				assert.Require(t, assert.NotEmpty(t, inlinedObjects))
 			default:

--- a/pkg/openslosdk/test_data/export/inputs/custom_config.yaml
+++ b/pkg/openslosdk/test_data/export/inputs/custom_config.yaml
@@ -1,0 +1,88 @@
+- apiVersion: openslo/v1
+  kind: SLO
+  metadata:
+    name: my-slo
+  spec:
+    service: web
+    indicator:
+      metadata:
+        name: my-sli
+      spec:
+        thresholdMetric:
+          metricSource:
+            metricSourceRef: my-prometheus
+            type: Prometheus
+            spec:
+              query: |
+                sum(min_over_time(kafka_consumergroup_lag{k8s_cluster="prod", consumergroup="annotator", topic="annotator-in"}[2m]))
+    timeWindow:
+      - duration: 1w
+        isRolling: false
+        calendar:
+          startTime: 2022-01-01 12:00:00
+          timeZone: America/New_York
+    budgetingMethod: Timeslices
+    objectives:
+      - displayName: Good
+        op: gt
+        target: 0.995
+        timeSliceTarget: 0.95
+        timeSliceWindow: 1m
+    alertPolicies:
+      - kind: AlertPolicy
+        metadata:
+          name: single-referenced-object
+        spec:
+          alertWhenBreaching: true
+          conditions:
+            - conditionRef: cpu-usage-breach
+          notificationTargets:
+            - targetRef: devs-email-notification
+      - kind: AlertPolicy
+        metadata:
+          name: mix-of-referenced-and-inlined-objects
+        spec:
+          alertWhenBreaching: true
+          conditions:
+            - kind: AlertCondition
+              metadata:
+                name: memory-usage-breach
+              spec:
+                severity: page
+                condition:
+                  kind: burnrate
+                  op: gt
+                  threshold: 2
+                  lookbackWindow: 1h
+                  alertAfter: 5m
+          notificationTargets:
+            - kind: AlertNotificationTarget
+              metadata:
+                name: pd-on-call-notification
+              spec:
+                target: pagerduty
+- apiVersion: openslo/v1
+  kind: AlertPolicy
+  metadata:
+    name: mix-of-referenced-and-inlined-objects
+  spec:
+    alertWhenBreaching: true
+    conditions:
+      - kind: AlertCondition
+        metadata:
+          name: memory-usage-breach
+        spec:
+          severity: page
+          condition:
+            kind: burnrate
+            op: gt
+            threshold: 2
+            lookbackWindow: 1h
+            alertAfter: 5m
+    notificationTargets:
+      - kind: AlertNotificationTarget
+        metadata:
+          name: pd-on-call-notification
+        spec:
+          target: pagerduty
+      - targetRef: devs-email-notification

--- a/pkg/openslosdk/test_data/export/outputs/custom_config.yaml
+++ b/pkg/openslosdk/test_data/export/outputs/custom_config.yaml
@@ -1,0 +1,88 @@
+- apiVersion: openslo/v1
+  kind: SLO
+  metadata:
+    name: my-slo
+  spec:
+    alertPolicies:
+    - kind: AlertPolicy
+      metadata:
+        name: single-referenced-object
+      spec:
+        alertWhenBreaching: true
+        conditions:
+        - conditionRef: cpu-usage-breach
+        notificationTargets:
+        - targetRef: devs-email-notification
+    - kind: AlertPolicy
+      metadata:
+        name: mix-of-referenced-and-inlined-objects
+      spec:
+        alertWhenBreaching: true
+        conditions:
+        - kind: AlertCondition
+          metadata:
+            name: memory-usage-breach
+          spec:
+            condition:
+              alertAfter: 5m
+              kind: burnrate
+              lookbackWindow: 1h
+              op: gt
+              threshold: 2
+            severity: page
+        notificationTargets:
+        - kind: AlertNotificationTarget
+          metadata:
+            name: pd-on-call-notification
+          spec:
+            target: pagerduty
+    budgetingMethod: Timeslices
+    indicator:
+      metadata:
+        name: my-sli
+      spec:
+        thresholdMetric:
+          metricSource:
+            metricSourceRef: my-prometheus
+            spec:
+              query: |
+                sum(min_over_time(kafka_consumergroup_lag{k8s_cluster="prod", consumergroup="annotator", topic="annotator-in"}[2m]))
+            type: Prometheus
+    objectives:
+    - displayName: Good
+      op: gt
+      target: 0.995
+      timeSliceTarget: 0.95
+      timeSliceWindow: 1m
+    service: web
+    timeWindow:
+    - calendar:
+        startTime: "2022-01-01 12:00:00"
+        timeZone: America/New_York
+      duration: 1w
+      isRolling: false
+- apiVersion: openslo/v1
+  kind: AlertPolicy
+  metadata:
+    name: mix-of-referenced-and-inlined-objects
+  spec:
+    alertWhenBreaching: true
+    conditions:
+    - kind: AlertCondition
+      metadata:
+        name: memory-usage-breach
+      spec:
+        condition:
+          alertAfter: 5m
+          kind: burnrate
+          lookbackWindow: 1h
+          op: gt
+          threshold: 2
+        severity: page
+    notificationTargets:
+    - kind: AlertNotificationTarget
+      metadata:
+        name: pd-on-call-notification
+      spec:
+        target: pagerduty
+    - targetRef: devs-email-notification

--- a/pkg/openslosdk/test_data/inline/inputs/custom_config.yaml
+++ b/pkg/openslosdk/test_data/inline/inputs/custom_config.yaml
@@ -1,0 +1,33 @@
+- apiVersion: openslo/v1
+  kind: AlertPolicy
+  metadata:
+    name: multiple-referenced-objects
+  spec:
+    alertWhenBreaching: true
+    conditions:
+      - conditionRef: cpu-usage-breach
+    notificationTargets:
+      - targetRef: pd-on-call-notification
+- apiVersion: openslo/v1
+  kind: SLO
+  metadata:
+    name: my-slo
+  spec:
+    alertPolicies:
+    - alertPolicyRef: single-referenced-object
+    - alertPolicyRef: mix-of-referenced-and-inlined-objects
+    budgetingMethod: Timeslices
+    indicatorRef: my-sli
+    objectives:
+    - displayName: Good
+      op: gt
+      target: 0.995
+      timeSliceTarget: 0.95
+      timeSliceWindow: 1m
+    service: web
+    timeWindow:
+    - calendar:
+        startTime: "2022-01-01 12:00:00"
+        timeZone: America/New_York
+      duration: 1w
+      isRolling: false

--- a/pkg/openslosdk/test_data/inline/inputs/v1_slo.yaml
+++ b/pkg/openslosdk/test_data/inline/inputs/v1_slo.yaml
@@ -1,7 +1,37 @@
 - apiVersion: openslo/v1
   kind: SLO
   metadata:
-    name: my-slo
+    name: my-slo-1
+  spec:
+    service: web
+    indicator:
+      metadata:
+        name: my-sli
+      spec:
+        thresholdMetric:
+          metricSource:
+            metricSourceRef: my-prometheus
+            type: Prometheus
+            spec:
+              query: |
+                sum(min_over_time(kafka_consumergroup_lag{k8s_cluster="prod", consumergroup="annotator", topic="annotator-in"}[2m]))
+    timeWindow:
+      - duration: 1w
+        isRolling: false
+        calendar:
+          startTime: 2022-01-01 12:00:00
+          timeZone: America/New_York
+    budgetingMethod: Timeslices
+    objectives:
+      - displayName: Good
+        op: gt
+        target: 0.995
+        timeSliceTarget: 0.95
+        timeSliceWindow: 1m
+- apiVersion: openslo/v1
+  kind: SLO
+  metadata:
+    name: my-slo-2
   spec:
     service: web
     indicatorRef: my-sli

--- a/pkg/openslosdk/test_data/inline/outputs/custom_config.yaml
+++ b/pkg/openslosdk/test_data/inline/outputs/custom_config.yaml
@@ -1,0 +1,33 @@
+- apiVersion: openslo/v1
+  kind: AlertPolicy
+  metadata:
+    name: multiple-referenced-objects
+  spec:
+    alertWhenBreaching: true
+    conditions:
+    - conditionRef: cpu-usage-breach
+    notificationTargets:
+    - targetRef: pd-on-call-notification
+- apiVersion: openslo/v1
+  kind: SLO
+  metadata:
+    name: my-slo
+  spec:
+    alertPolicies:
+    - alertPolicyRef: single-referenced-object
+    - alertPolicyRef: mix-of-referenced-and-inlined-objects
+    budgetingMethod: Timeslices
+    indicatorRef: my-sli
+    objectives:
+    - displayName: Good
+      op: gt
+      target: 0.995
+      timeSliceTarget: 0.95
+      timeSliceWindow: 1m
+    service: web
+    timeWindow:
+    - calendar:
+        startTime: "2022-01-01 12:00:00"
+        timeZone: America/New_York
+      duration: 1w
+      isRolling: false

--- a/pkg/openslosdk/test_data/inline/outputs/v1_slo.yaml
+++ b/pkg/openslosdk/test_data/inline/outputs/v1_slo.yaml
@@ -1,7 +1,37 @@
 - apiVersion: openslo/v1
   kind: SLO
   metadata:
-    name: my-slo
+    name: my-slo-1
+  spec:
+    budgetingMethod: Timeslices
+    indicator:
+      metadata:
+        name: my-sli
+      spec:
+        thresholdMetric:
+          metricSource:
+            metricSourceRef: my-prometheus
+            spec:
+              query: |
+                sum(min_over_time(kafka_consumergroup_lag{k8s_cluster="prod", consumergroup="annotator", topic="annotator-in"}[2m]))
+            type: Prometheus
+    objectives:
+    - displayName: Good
+      op: gt
+      target: 0.995
+      timeSliceTarget: 0.95
+      timeSliceWindow: 1m
+    service: web
+    timeWindow:
+    - calendar:
+        startTime: "2022-01-01 12:00:00"
+        timeZone: America/New_York
+      duration: 1w
+      isRolling: false
+- apiVersion: openslo/v1
+  kind: SLO
+  metadata:
+    name: my-slo-2
   spec:
     alertPolicies:
     - kind: AlertPolicy


### PR DESCRIPTION
When working with AlertPolicy or SLO we might want to only resolve (either inline or export) specific dependency objects.

For instance, Nobl9 does not have a separate SLI object and requires the SLO to have it inlined, but at the same time it expects AlertNotificaitonTarget to be a separate entity (it maps directly to Nobl9 AlertMethod object).
Due to these requirements some objects need to be inlined why others exported before a conversion between OpenSLO and Nobl9 can be achieved.

In order to aid in meeting such more complex requirements we're introducing `ReferenceConfig` struct which gives fine-grained control to the `openslosdk` user when both inlining and exporting object dependencies.