### PR TITLE
feat: Add per-version Object interface

### DIFF
--- a/pkg/openslo/v1/alert_condition.go
+++ b/pkg/openslo/v1/alert_condition.go
@@ -8,7 +8,7 @@ import (
 	"github.com/OpenSLO/go-sdk/pkg/openslo"
 )
 
-var _ = openslo.Object(AlertCondition{})
+var _ = Object(AlertCondition{})
 
 func NewAlertCondition(metadata Metadata, spec AlertConditionSpec) AlertCondition {
 	return AlertCondition{
@@ -44,6 +44,10 @@ func (a AlertCondition) Validate() error {
 
 func (a AlertCondition) String() string {
 	return internal.GetObjectName(a)
+}
+
+func (a AlertCondition) GetMetadata() Metadata {
+	return a.Metadata
 }
 
 type AlertConditionSpec struct {

--- a/pkg/openslo/v1/alert_notification_target.go
+++ b/pkg/openslo/v1/alert_notification_target.go
@@ -8,7 +8,7 @@ import (
 	"github.com/OpenSLO/go-sdk/pkg/openslo"
 )
 
-var _ = openslo.Object(AlertNotificationTarget{})
+var _ = Object(AlertNotificationTarget{})
 
 func NewAlertNotificationTarget(metadata Metadata, spec AlertNotificationTargetSpec) AlertNotificationTarget {
 	return AlertNotificationTarget{
@@ -44,6 +44,10 @@ func (a AlertNotificationTarget) Validate() error {
 
 func (a AlertNotificationTarget) String() string {
 	return internal.GetObjectName(a)
+}
+
+func (a AlertNotificationTarget) GetMetadata() Metadata {
+	return a.Metadata
 }
 
 type AlertNotificationTargetSpec struct {

--- a/pkg/openslo/v1/alert_policy.go
+++ b/pkg/openslo/v1/alert_policy.go
@@ -8,7 +8,7 @@ import (
 	"github.com/OpenSLO/go-sdk/pkg/openslo"
 )
 
-var _ = openslo.Object(AlertPolicy{})
+var _ = Object(AlertPolicy{})
 
 func NewAlertPolicy(metadata Metadata, spec AlertPolicySpec) AlertPolicy {
 	return AlertPolicy{
@@ -44,6 +44,10 @@ func (a AlertPolicy) Validate() error {
 
 func (a AlertPolicy) String() string {
 	return internal.GetObjectName(a)
+}
+
+func (a AlertPolicy) GetMetadata() Metadata {
+	return a.Metadata
 }
 
 type AlertPolicySpec struct {

--- a/pkg/openslo/v1/data_source.go
+++ b/pkg/openslo/v1/data_source.go
@@ -10,7 +10,7 @@ import (
 	"github.com/OpenSLO/go-sdk/pkg/openslo"
 )
 
-var _ = openslo.Object(DataSource{})
+var _ = Object(DataSource{})
 
 func NewDataSource(metadata Metadata, spec DataSourceSpec) DataSource {
 	return DataSource{
@@ -46,6 +46,10 @@ func (d DataSource) Validate() error {
 
 func (d DataSource) String() string {
 	return internal.GetObjectName(d)
+}
+
+func (d DataSource) GetMetadata() Metadata {
+	return d.Metadata
 }
 
 type DataSourceSpec struct {

--- a/pkg/openslo/v1/objects.go
+++ b/pkg/openslo/v1/objects.go
@@ -27,6 +27,11 @@ func GetSupportedKinds() []openslo.Kind {
 	return slices.Clone(supportedKinds)
 }
 
+type Object interface {
+	openslo.Object
+	GetMetadata() Metadata
+}
+
 type Metadata struct {
 	Name        string      `json:"name"`
 	DisplayName string      `json:"displayName,omitempty"`

--- a/pkg/openslo/v1/service.go
+++ b/pkg/openslo/v1/service.go
@@ -8,7 +8,7 @@ import (
 	"github.com/OpenSLO/go-sdk/pkg/openslo"
 )
 
-var _ = openslo.Object(Service{})
+var _ = Object(Service{})
 
 func NewService(metadata Metadata, spec ServiceSpec) Service {
 	return Service{
@@ -44,6 +44,10 @@ func (s Service) Validate() error {
 
 func (s Service) String() string {
 	return internal.GetObjectName(s)
+}
+
+func (s Service) GetMetadata() Metadata {
+	return s.Metadata
 }
 
 type ServiceSpec struct {

--- a/pkg/openslo/v1/sli.go
+++ b/pkg/openslo/v1/sli.go
@@ -8,7 +8,7 @@ import (
 	"github.com/OpenSLO/go-sdk/pkg/openslo"
 )
 
-var _ = openslo.Object(SLI{})
+var _ = Object(SLI{})
 
 func NewSLI(metadata Metadata, spec SLISpec) SLI {
 	return SLI{
@@ -44,6 +44,10 @@ func (s SLI) Validate() error {
 
 func (s SLI) String() string {
 	return internal.GetObjectName(s)
+}
+
+func (s SLI) GetMetadata() Metadata {
+	return s.Metadata
 }
 
 type SLISpec struct {

--- a/pkg/openslo/v1/slo.go
+++ b/pkg/openslo/v1/slo.go
@@ -11,7 +11,7 @@ import (
 	"github.com/OpenSLO/go-sdk/pkg/openslo"
 )
 
-var _ = openslo.Object(SLO{})
+var _ = Object(SLO{})
 
 func NewSLO(metadata Metadata, spec SLOSpec) SLO {
 	return SLO{
@@ -51,6 +51,10 @@ func (s SLO) String() string {
 
 func (s SLO) IsComposite() bool {
 	return s.Spec.HasCompositeObjectives()
+}
+
+func (s SLO) GetMetadata() Metadata {
+	return s.Metadata
 }
 
 type SLOSpec struct {

--- a/pkg/openslo/v1alpha/objects.go
+++ b/pkg/openslo/v1alpha/objects.go
@@ -20,6 +20,11 @@ func GetSupportedKinds() []openslo.Kind {
 	return slices.Clone(supportedKinds)
 }
 
+type Object interface {
+	openslo.Object
+	GetMetadata() Metadata
+}
+
 type Metadata struct {
 	Name        string `json:"name"`
 	DisplayName string `json:"displayName,omitempty"`

--- a/pkg/openslo/v1alpha/service.go
+++ b/pkg/openslo/v1alpha/service.go
@@ -8,7 +8,7 @@ import (
 	"github.com/OpenSLO/go-sdk/pkg/openslo"
 )
 
-var _ = openslo.Object(Service{})
+var _ = Object(Service{})
 
 func NewService(metadata Metadata, spec ServiceSpec) Service {
 	return Service{
@@ -44,6 +44,10 @@ func (s Service) Validate() error {
 
 func (s Service) String() string {
 	return internal.GetObjectName(s)
+}
+
+func (s Service) GetMetadata() Metadata {
+	return s.Metadata
 }
 
 type ServiceSpec struct {

--- a/pkg/openslo/v1alpha/slo.go
+++ b/pkg/openslo/v1alpha/slo.go
@@ -11,7 +11,7 @@ import (
 	"github.com/OpenSLO/go-sdk/pkg/openslo"
 )
 
-var _ = openslo.Object(SLO{})
+var _ = Object(SLO{})
 
 func NewSLO(metadata Metadata, spec SLOSpec) SLO {
 	return SLO{
@@ -47,6 +47,10 @@ func (s SLO) Validate() error {
 
 func (s SLO) String() string {
 	return internal.GetObjectName(s)
+}
+
+func (s SLO) GetMetadata() Metadata {
+	return s.Metadata
 }
 
 type SLOSpec struct {

--- a/pkg/openslo/v2alpha/alert_condition.go
+++ b/pkg/openslo/v2alpha/alert_condition.go
@@ -8,7 +8,7 @@ import (
 	"github.com/OpenSLO/go-sdk/pkg/openslo"
 )
 
-var _ = openslo.Object(AlertCondition{})
+var _ = Object(AlertCondition{})
 
 func NewAlertCondition(metadata Metadata, spec AlertConditionSpec) AlertCondition {
 	return AlertCondition{
@@ -44,6 +44,10 @@ func (a AlertCondition) Validate() error {
 
 func (a AlertCondition) String() string {
 	return internal.GetObjectName(a)
+}
+
+func (a AlertCondition) GetMetadata() Metadata {
+	return a.Metadata
 }
 
 type AlertConditionSpec struct {

--- a/pkg/openslo/v2alpha/alert_notification_target.go
+++ b/pkg/openslo/v2alpha/alert_notification_target.go
@@ -8,7 +8,7 @@ import (
 	"github.com/OpenSLO/go-sdk/pkg/openslo"
 )
 
-var _ = openslo.Object(AlertNotificationTarget{})
+var _ = Object(AlertNotificationTarget{})
 
 func NewAlertNotificationTarget(metadata Metadata, spec AlertNotificationTargetSpec) AlertNotificationTarget {
 	return AlertNotificationTarget{
@@ -44,6 +44,10 @@ func (a AlertNotificationTarget) Validate() error {
 
 func (a AlertNotificationTarget) String() string {
 	return internal.GetObjectName(a)
+}
+
+func (a AlertNotificationTarget) GetMetadata() Metadata {
+	return a.Metadata
 }
 
 type AlertNotificationTargetSpec struct {

--- a/pkg/openslo/v2alpha/alert_policy.go
+++ b/pkg/openslo/v2alpha/alert_policy.go
@@ -8,7 +8,7 @@ import (
 	"github.com/OpenSLO/go-sdk/pkg/openslo"
 )
 
-var _ = openslo.Object(AlertPolicy{})
+var _ = Object(AlertPolicy{})
 
 func NewAlertPolicy(metadata Metadata, spec AlertPolicySpec) AlertPolicy {
 	return AlertPolicy{
@@ -44,6 +44,10 @@ func (a AlertPolicy) Validate() error {
 
 func (a AlertPolicy) String() string {
 	return internal.GetObjectName(a)
+}
+
+func (a AlertPolicy) GetMetadata() Metadata {
+	return a.Metadata
 }
 
 type AlertPolicySpec struct {

--- a/pkg/openslo/v2alpha/data_source.go
+++ b/pkg/openslo/v2alpha/data_source.go
@@ -10,7 +10,7 @@ import (
 	"github.com/OpenSLO/go-sdk/pkg/openslo"
 )
 
-var _ = openslo.Object(DataSource{})
+var _ = Object(DataSource{})
 
 func NewDataSource(metadata Metadata, spec DataSourceSpec) DataSource {
 	return DataSource{
@@ -46,6 +46,10 @@ func (d DataSource) Validate() error {
 
 func (d DataSource) String() string {
 	return internal.GetObjectName(d)
+}
+
+func (d DataSource) GetMetadata() Metadata {
+	return d.Metadata
 }
 
 type DataSourceSpec struct {

--- a/pkg/openslo/v2alpha/objects.go
+++ b/pkg/openslo/v2alpha/objects.go
@@ -26,6 +26,11 @@ func GetSupportedKinds() []openslo.Kind {
 	return slices.Clone(supportedKinds)
 }
 
+type Object interface {
+	openslo.Object
+	GetMetadata() Metadata
+}
+
 type Metadata struct {
 	Name        string      `json:"name"`
 	Labels      Labels      `json:"labels,omitempty"`

--- a/pkg/openslo/v2alpha/service.go
+++ b/pkg/openslo/v2alpha/service.go
@@ -8,7 +8,7 @@ import (
 	"github.com/OpenSLO/go-sdk/pkg/openslo"
 )
 
-var _ = openslo.Object(Service{})
+var _ = Object(Service{})
 
 func NewService(metadata Metadata, spec ServiceSpec) Service {
 	return Service{
@@ -44,6 +44,10 @@ func (s Service) Validate() error {
 
 func (s Service) String() string {
 	return internal.GetObjectName(s)
+}
+
+func (s Service) GetMetadata() Metadata {
+	return s.Metadata
 }
 
 type ServiceSpec struct {

--- a/pkg/openslo/v2alpha/sli.go
+++ b/pkg/openslo/v2alpha/sli.go
@@ -8,7 +8,7 @@ import (
 	"github.com/OpenSLO/go-sdk/pkg/openslo"
 )
 
-var _ = openslo.Object(SLI{})
+var _ = Object(SLI{})
 
 func NewSLI(metadata Metadata, spec SLISpec) SLI {
 	return SLI{
@@ -44,6 +44,10 @@ func (s SLI) Validate() error {
 
 func (s SLI) String() string {
 	return internal.GetObjectName(s)
+}
+
+func (s SLI) GetMetadata() Metadata {
+	return s.Metadata
 }
 
 type SLISpec struct {

--- a/pkg/openslo/v2alpha/slo.go
+++ b/pkg/openslo/v2alpha/slo.go
@@ -11,7 +11,7 @@ import (
 	"github.com/OpenSLO/go-sdk/pkg/openslo"
 )
 
-var _ = openslo.Object(SLO{})
+var _ = Object(SLO{})
 
 func NewSLO(metadata Metadata, spec SLOSpec) SLO {
 	return SLO{
@@ -47,6 +47,10 @@ func (s SLO) Validate() error {
 
 func (s SLO) String() string {
 	return internal.GetObjectName(s)
+}
+
+func (s SLO) GetMetadata() Metadata {
+	return s.Metadata
 }
 
 func (s SLO) IsComposite() bool {

--- a/pkg/openslosdk/objects.go
+++ b/pkg/openslosdk/objects.go
@@ -2,8 +2,11 @@ package openslosdk
 
 import "github.com/OpenSLO/go-sdk/pkg/openslo"
 
-// FilterByKind filters [openslo.Object] slice and returns its subset matching the type constraint.
-func FilterByKind[T openslo.Object](objects []openslo.Object) []T {
+// FilterByType filters [openslo.Object] slice and returns its subset matching the type constraint.
+// You can use it to filter:
+//   - specific version and kind, like [v1.SLO]
+//   - specific version, like [v1.Object]
+func FilterByType[T openslo.Object](objects []openslo.Object) []T {
 	var filtered []T
 	for i := range objects {
 		if v, ok := objects[i].(T); ok {

--- a/pkg/openslosdk/objects_test.go
+++ b/pkg/openslosdk/objects_test.go
@@ -8,7 +8,7 @@ import (
 	v1 "github.com/OpenSLO/go-sdk/pkg/openslo/v1"
 )
 
-func TestFilterByKind(t *testing.T) {
+func TestFilterByType(t *testing.T) {
 	tests := map[string]struct {
 		objects  []openslo.Object
 		expected any
@@ -63,13 +63,13 @@ func TestFilterByKind(t *testing.T) {
 			var result any
 			switch name {
 			case "Filter v1.SLO":
-				result = FilterByKind[v1.SLO](tc.objects)
+				result = FilterByType[v1.SLO](tc.objects)
 			case "Filter v1.Service":
-				result = FilterByKind[v1.Service](tc.objects)
+				result = FilterByType[v1.Service](tc.objects)
 			case "Filter v1.DataSource":
-				result = FilterByKind[v1.DataSource](tc.objects)
+				result = FilterByType[v1.DataSource](tc.objects)
 			case "Filter mockObject":
-				result = FilterByKind[mockObject](tc.objects)
+				result = FilterByType[mockObject](tc.objects)
 			default:
 				t.Fatalf("unexpected test case: %s", name)
 			}


### PR DESCRIPTION
Each OpenSLO version now has an `Object` interface which extends `openslo.Object` interface with version specific, common methods.

**BREAKING CHANGES**: `openslosdk.FilterByKind` has been renamed to `FilterByType` to better reflect its usage.