### PR TITLE
feat: Expose validator for each object

### DIFF
--- a/pkg/openslo/v1/alert_condition.go
+++ b/pkg/openslo/v1/alert_condition.go
@@ -50,6 +50,10 @@ func (a AlertCondition) GetMetadata() Metadata {
 	return a.Metadata
 }
 
+func (a AlertCondition) GetValidator() govy.Validator[AlertCondition] {
+	return alertConditionValidation
+}
+
 type AlertConditionSpec struct {
 	Severity    string             `json:"severity"`
 	Condition   AlertConditionType `json:"condition"`

--- a/pkg/openslo/v1/alert_notification_target.go
+++ b/pkg/openslo/v1/alert_notification_target.go
@@ -50,6 +50,10 @@ func (a AlertNotificationTarget) GetMetadata() Metadata {
 	return a.Metadata
 }
 
+func (a AlertNotificationTarget) GetValidator() govy.Validator[AlertNotificationTarget] {
+	return alertNotificationTargetValidation
+}
+
 type AlertNotificationTargetSpec struct {
 	Description string `json:"description,omitempty"`
 	Target      string `json:"target"`

--- a/pkg/openslo/v1/alert_policy.go
+++ b/pkg/openslo/v1/alert_policy.go
@@ -50,6 +50,10 @@ func (a AlertPolicy) GetMetadata() Metadata {
 	return a.Metadata
 }
 
+func (a AlertPolicy) GetValidator() govy.Validator[AlertPolicy] {
+	return alertPolicyValidation
+}
+
 type AlertPolicySpec struct {
 	Description         string                          `json:"description,omitempty"`
 	AlertWhenNoData     bool                            `json:"alertWhenNoData,omitempty"`

--- a/pkg/openslo/v1/data_source.go
+++ b/pkg/openslo/v1/data_source.go
@@ -52,6 +52,10 @@ func (d DataSource) GetMetadata() Metadata {
 	return d.Metadata
 }
 
+func (d DataSource) GetValidator() govy.Validator[DataSource] {
+	return dataSourceValidation
+}
+
 type DataSourceSpec struct {
 	Description       string          `json:"description,omitempty"`
 	Type              string          `json:"type"`

--- a/pkg/openslo/v1/service.go
+++ b/pkg/openslo/v1/service.go
@@ -50,6 +50,10 @@ func (s Service) GetMetadata() Metadata {
 	return s.Metadata
 }
 
+func (s Service) GetValidator() govy.Validator[Service] {
+	return serviceValidation
+}
+
 type ServiceSpec struct {
 	Description string `json:"description,omitempty"`
 }

--- a/pkg/openslo/v1/sli.go
+++ b/pkg/openslo/v1/sli.go
@@ -50,6 +50,10 @@ func (s SLI) GetMetadata() Metadata {
 	return s.Metadata
 }
 
+func (s SLI) GetValidator() govy.Validator[SLI] {
+	return sliValidation
+}
+
 type SLISpec struct {
 	Description     string          `json:"description,omitempty"`
 	ThresholdMetric *SLIMetricSpec  `json:"thresholdMetric,omitempty"`

--- a/pkg/openslo/v1/slo.go
+++ b/pkg/openslo/v1/slo.go
@@ -57,6 +57,10 @@ func (s SLO) GetMetadata() Metadata {
 	return s.Metadata
 }
 
+func (s SLO) GetValidator() govy.Validator[SLO] {
+	return sloValidation
+}
+
 type SLOSpec struct {
 	Description     string              `json:"description,omitempty"`
 	Service         string              `json:"service"`

--- a/pkg/openslo/v1alpha/service.go
+++ b/pkg/openslo/v1alpha/service.go
@@ -50,6 +50,10 @@ func (s Service) GetMetadata() Metadata {
 	return s.Metadata
 }
 
+func (s Service) GetValidator() govy.Validator[Service] {
+	return serviceValidation
+}
+
 type ServiceSpec struct {
 	Description string `json:"description,omitempty"`
 }

--- a/pkg/openslo/v1alpha/slo.go
+++ b/pkg/openslo/v1alpha/slo.go
@@ -53,6 +53,10 @@ func (s SLO) GetMetadata() Metadata {
 	return s.Metadata
 }
 
+func (s SLO) GetValidator() govy.Validator[SLO] {
+	return sloValidation
+}
+
 type SLOSpec struct {
 	TimeWindows     []SLOTimeWindow    `json:"timeWindows"`
 	BudgetingMethod SLOBudgetingMethod `json:"budgetingMethod"`

--- a/pkg/openslo/v2alpha/alert_condition.go
+++ b/pkg/openslo/v2alpha/alert_condition.go
@@ -50,6 +50,10 @@ func (a AlertCondition) GetMetadata() Metadata {
 	return a.Metadata
 }
 
+func (a AlertCondition) GetValidator() govy.Validator[AlertCondition] {
+	return alertConditionValidation
+}
+
 type AlertConditionSpec struct {
 	Severity    string             `json:"severity"`
 	Condition   AlertConditionType `json:"condition"`

--- a/pkg/openslo/v2alpha/alert_notification_target.go
+++ b/pkg/openslo/v2alpha/alert_notification_target.go
@@ -50,6 +50,10 @@ func (a AlertNotificationTarget) GetMetadata() Metadata {
 	return a.Metadata
 }
 
+func (a AlertNotificationTarget) GetValidator() govy.Validator[AlertNotificationTarget] {
+	return alertNotificationTargetValidation
+}
+
 type AlertNotificationTargetSpec struct {
 	Description string `json:"description,omitempty"`
 	Target      string `json:"target"`

--- a/pkg/openslo/v2alpha/alert_policy.go
+++ b/pkg/openslo/v2alpha/alert_policy.go
@@ -50,6 +50,10 @@ func (a AlertPolicy) GetMetadata() Metadata {
 	return a.Metadata
 }
 
+func (a AlertPolicy) GetValidator() govy.Validator[AlertPolicy] {
+	return alertPolicyValidation
+}
+
 type AlertPolicySpec struct {
 	Description         string                          `json:"description,omitempty"`
 	AlertWhenNoData     bool                            `json:"alertWhenNoData,omitempty"`

--- a/pkg/openslo/v2alpha/data_source.go
+++ b/pkg/openslo/v2alpha/data_source.go
@@ -52,6 +52,10 @@ func (d DataSource) GetMetadata() Metadata {
 	return d.Metadata
 }
 
+func (d DataSource) GetValidator() govy.Validator[DataSource] {
+	return dataSourceValidation
+}
+
 type DataSourceSpec struct {
 	Description       string          `json:"description,omitempty"`
 	Type              string          `json:"type"`

--- a/pkg/openslo/v2alpha/service.go
+++ b/pkg/openslo/v2alpha/service.go
@@ -50,6 +50,10 @@ func (s Service) GetMetadata() Metadata {
 	return s.Metadata
 }
 
+func (s Service) GetValidator() govy.Validator[Service] {
+	return serviceValidation
+}
+
 type ServiceSpec struct {
 	Description string `json:"description,omitempty"`
 }

--- a/pkg/openslo/v2alpha/sli.go
+++ b/pkg/openslo/v2alpha/sli.go
@@ -50,6 +50,10 @@ func (s SLI) GetMetadata() Metadata {
 	return s.Metadata
 }
 
+func (s SLI) GetValidator() govy.Validator[SLI] {
+	return sliValidation
+}
+
 type SLISpec struct {
 	Description     string          `json:"description,omitempty"`
 	ThresholdMetric *SLIMetricSpec  `json:"thresholdMetric,omitempty"`

--- a/pkg/openslo/v2alpha/slo.go
+++ b/pkg/openslo/v2alpha/slo.go
@@ -57,6 +57,10 @@ func (s SLO) IsComposite() bool {
 	return s.Spec.HasCompositeObjectives()
 }
 
+func (s SLO) GetValidator() govy.Validator[SLO] {
+	return sloValidation
+}
+
 type SLOSpec struct {
 	Description     string             `json:"description,omitempty"`
 	Service         string             `json:"service"`


### PR DESCRIPTION
In order to be able to generate documentation from `govy.Plan` outside of this repository, we need to be able to access the `govy.Validator` for each OpenSLO object.